### PR TITLE
asynchronous spelling typo corrected

### DIFF
--- a/docs/integrations-guides/dispersal/api-documentation/overview.md
+++ b/docs/integrations-guides/dispersal/api-documentation/overview.md
@@ -31,7 +31,7 @@ graph TD;
     C -->|15 days elapses since dispersal finalization| D[Blob Expired];
 ```
 
-The Disperser offers an asynchrounous API for dispersing blobs, where clients should poll the `GetBlobStatus()` endpoint with the dispersal request ID they received from calling one of the two disperse endpoints until the disperser reports the blob as successfully dispersed and finalized.
+The Disperser offers an asynchronous API for dispersing blobs, where clients should poll the `GetBlobStatus()` endpoint with the dispersal request ID they received from calling one of the two disperse endpoints until the disperser reports the blob as successfully dispersed and finalized.
 
 ## Endpoints
 


### PR DESCRIPTION
In [dispersal api docs](https://eigenda-docs-phi.vercel.app/integrations-guides/dispersal/api-documentation/overview) small typo corrected.

![image](https://github.com/user-attachments/assets/2841a180-0e43-4b72-a93c-0ecbb746ed8a)