### PR TITLE
Update max blob size to 16MB

### DIFF
--- a/docs/networks/holesky.md
+++ b/docs/networks/holesky.md
@@ -19,7 +19,7 @@ The EigenDA Holesky testnet is the current EigenDA testnet. The EigenDA Holesky 
 | Disperser Address | `disperser-holesky.eigenda.xyz:443` |
 | Churner Address | `churner-holesky.eigenda.xyz:443` |
 | Batch Confirmation Interval | Every 10 minutes (may vary based on network health) |
-| Max Blob Size | 2 MB |
+| Max Blob Size | 16 MB |
 | Default Blob Dispersal Rate limit | No more than 1 blob every 100 seconds |
 | Default Blob Size Rate Limit | No more than 1.8 MB every 10 minutes |
 | Stake Sync (AVS-Sync) Interval | Every 24 hours |

--- a/docs/networks/mainnet.md
+++ b/docs/networks/mainnet.md
@@ -17,7 +17,7 @@ sidebar_position: 3
 | Disperser Address | `disperser.eigenda.xyz:443` |
 | Churner Address | `churner.eigenda.xyz:443` |
 | Batch Confirmation Interval | Every 10 minutes (may vary based on network health) |
-| Max Blob Size | 2 MB |
+| Max Blob Size | 16 MB |
 | Stake Sync (AVS-Sync) Interval | Every 6 days |
 | Ejection Cooldown Period | 3 days |
 


### PR DESCRIPTION
Network docs were out of date showing 2MB instead of correct 16MB for max blob size