### PR TITLE
Typo fix  operator-faq.md

### DIFF
--- a/docs/operator-guides/operator-faq.md
+++ b/docs/operator-guides/operator-faq.md
@@ -12,7 +12,7 @@ If you have a static IP address or DNS address set up to receive the traffic
 and you don't want EigenDA to automatically update IP which is sent to EigenDA
 while registering, then follow the steps to make sure correct IP is registered:
 
-* Update the [NODE_HOSTNAME](https://github.com/Layr-Labs/eigenda-operator-setup/blob/31d99e2aa67962878969b81a15c7e8d13ee69750/mainnet/.env.example#L71) to the public IP where you will want to recieve traffic.
+* Update the [NODE_HOSTNAME](https://github.com/Layr-Labs/eigenda-operator-setup/blob/31d99e2aa67962878969b81a15c7e8d13ee69750/mainnet/.env.example#L71) to the public IP where you will want to receive traffic.
 * Opt-in using the [provided steps](./run-a-node/registration/).
 * In order to disable the node IP address from being automatically updated, set the value of [NODE_PUBLIC_IP_CHECK_INTERVAL](https://github.com/Layr-Labs/eigenda-operator-setup/blob/31d99e2aa67962878969b81a15c7e8d13ee69750/mainnet/.env.example#L65) to `0`.
 


### PR DESCRIPTION
Corrected a typo in `docs/operator-guides/operator-faq.md`, changing **"recieve"** to **"receive"** for proper spelling.
