### PR TITLE
chore: fix MDX Plugin Imports to Prevent Unified Preset Error

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -260,8 +260,8 @@ const config = {
           sidebarPath: require.resolve("./sidebars.js"),
           breadcrumbs: true,
           routeBasePath: "/",
-          remarkPlugins: [math],
-          rehypePlugins: [katex],
+          remarkPlugins: [math.default],
+          rehypePlugins: [katex.default],
           showLastUpdateTime: false,
         },
         blog: {


### PR DESCRIPTION
## 🔧 Fix MDX Plugin Imports to Prevent Unified Preset Error

### 📋 Summary

This PR fixes an issue where the Docusaurus dev server fails to start locally with the following error:

```
[ERROR] Expected usable value but received an empty preset
```

The problem was caused by how `remark-math` and `rehype-katex` were imported in `docusaurus.config.js`. Since both are ES modules, using `require()` returns a wrapped object with a `.default` property. Passing the full object instead of the function caused `unified().use()` to receive an invalid preset.

### ✅ Fix

- Updated `remarkPlugins` and `rehypePlugins` to use `.default`:
  ```js
  remarkPlugins: [math.default],
  rehypePlugins: [katex.default],
  ```

### Node version
Closes #67 
