### PR TITLE
docs(op): add missing v2 migration info

### DIFF
--- a/docs/integrations-guides/rollup-guides/op-stack/README.md
+++ b/docs/integrations-guides/rollup-guides/op-stack/README.md
@@ -129,9 +129,9 @@ Failover was added in this [PR](https://github.com/Layr-Labs/optimism/pull/34), 
 
 For [trusted](../integrations-overview.md#trusted-integration) integrations, migrating to EigenDA V2 is as simple as:
 - op-node: restarting the eigenda-proxy to support [both V1 and V2 backends](https://github.com/Layr-Labs/eigenda-proxy/blob/5f887a68889437d88cd1d39c45c1327f78cd74a4/.env.exampleV1AndV2.holesky#L102)
-- op-batcher: restarting the eigenda-proxy to [disperse to V2](https://github.com/Layr-Labs/eigenda-proxy/blob/5f887a68889437d88cd1d39c45c1327f78cd74a4/.env.exampleV1AndV2.holesky#L106)
+- op-batcher: restarting the eigenda-proxy to [disperse to V2](https://github.com/Layr-Labs/eigenda-proxy/blob/5f887a68889437d88cd1d39c45c1327f78cd74a4/.env.exampleV1AndV2.holesky#L106). This will require setting a [V2_SIGNER_PRIVATE_KEY](https://github.com/Layr-Labs/eigenda-proxy/blob/5f887a68889437d88cd1d39c45c1327f78cd74a4/.env.exampleV1AndV2.holesky#L54) with [V2 payments](../../../releases/payments.md) enabled (either pay-per-blob or reserved bandwidth).
 
-Please refer to the [EigenDA Proxy README](https://github.com/Layr-Labs/eigenda-proxy?tab=readme-ov-file#migrating-from-eigenda-v1-to-v2) for more details.
+Please refer to the [EigenDA Proxy README](https://github.com/Layr-Labs/eigenda-proxy?tab=readme-ov-file#migrating-from-eigenda-v1-to-v2) for more details. We also have a V2 migration test on our kurtosis devnet which shows how to [swap the dispersal-backend](https://github.com/Layr-Labs/optimism/blob/89ac40d0fddba2e06854b253b9f0266f36350af2/kurtosis-devnet/tests/eigenda/v2_migration_test.go#L83) from V1 to V2 without needing to restart the proxy.
 
 ## Security Guarantees
 


### PR DESCRIPTION
Was missing payment related info, as well as pointing them to our v2 migration test on kurtosis devnet.