### PR TITLE
Update security model document to reflect chunk assignment optimization

### DIFF
--- a/docs/core-concepts/security/security-model.md
+++ b/docs/core-concepts/security/security-model.md
@@ -97,7 +97,9 @@ Note that EigenDA supports multiple quorums, and a single validator may particip
 ``GetChunkAssignments``
 
 The number of chunks assigned to validator $i$ is calculated by: 
-$$ m_i= \left\lceil\eta_i(m- \|N\|)\right\rceil, $$
+$$ 
+m_i= \left\lceil\eta_i(m- \|N\|)\right\rceil, 
+$$
 where $\|N\|$ is the actual number of operators. 
 We rank the validators in a deterministic order and then assign chunks sequentially until each validator $i$ has received $m_i$ chunks.
 


### PR DESCRIPTION
## Key Changes

1. The chunk assignment logic and the reconstruction proof were separated from the BFT security analysis. The chunk assignment module is used as a stepping stone toward establishing the BFT security.

2. Update the chunk assignment logic for reflect change in the implementation.

3. Describing the Optimizations introduced to reduce the total number of chunks assigned to each validator, and arguing that these changes preserve the reconstruction guarantees.
