### PR TITLE
feat: Link proxy releases, and remove 'v2 not on mainnet' statement

### DIFF
--- a/docs/integrations-guides/eigenda-proxy/eigenda-proxy.md
+++ b/docs/integrations-guides/eigenda-proxy/eigenda-proxy.md
@@ -1,14 +1,8 @@
 # EigenDA Proxy
 
 ## About
-EigenDA proxy is a sidecar server ran as part of a rollup node cluster for communication with the EigenDA network.
-
-### Key Releases
-| version | (mainnet) max blob size | (holesky) max blob size | supported stacks   | Cert version(s) |
-|---------|-------------------------|-------------------------|--------------------|-----------------|
-|  v1.3.1 |        `2mib`           |          `2mib`         |      OP Stack      |      v0         |
-|  v1.4   |        `4mib`           |          `16mib`        |      OP Stack      |      v0         |
-|  v1.4.1 |        `16mib`          |          `16mib`        |  OP Stack, Orbit   |      v0         |
+EigenDA proxy is a sidecar server ran as part of a rollup node cluster for communication with the EigenDA network. Information about 
+proxy releases can be found [here](https://github.com/Layr-Labs/eigenda-proxy/releases).
 
 ### Example Rollup interaction diagram
 *Shown below is a high level flow of how proxy is used across a rollup stack by different network roles (i.e, sequencer, verifier). Any rollup node using an eigenda integration who wishes to sync directly from the parent chain inbox or a safe head must run this service to do so.*

--- a/docs/networks/mainnet.md
+++ b/docs/networks/mainnet.md
@@ -44,6 +44,7 @@ sidebar_position: 1
 | IndexRegistry | [0xbd35a7a1cdef403a6a99e4e8ba0974d198455030](https://etherscan.io/address/0xbd35a7a1cdef403a6a99e4e8ba0974d198455030) |
 | BLSApkRegistry | [0x00a5fd09f6cee6ae9c8b0e5e33287f7c82880505](https://etherscan.io/address/0x00a5fd09f6cee6ae9c8b0e5e33287f7c82880505) |
 | EigenDAServiceManager | [0x870679e138bcdf293b7ff14dd44b70fc97e12fc0](https://etherscan.io/address/0x870679e138bcdf293b7ff14dd44b70fc97e12fc0) |
+| CertVerifier | [0xE1Ae45810A738F13e70Ac8966354d7D0feCF7BD6](https://etherscan.io/address/0xE1Ae45810A738F13e70Ac8966354d7D0feCF7BD6) |
 | BLSOperatorStateRetriever | [0xEC35aa6521d23479318104E10B4aA216DBBE63Ce](https://etherscan.io/address/0xEC35aa6521d23479318104E10B4aA216DBBE63Ce) |
 | PaymentVault | [0xb2e7ef419a2A399472ae22ef5cFcCb8bE97A4B05](https://etherscan.io/address/0xb2e7ef419a2A399472ae22ef5cFcCb8bE97A4B05) |
 

--- a/docs/operator-guides/overview.md
+++ b/docs/operator-guides/overview.md
@@ -11,7 +11,7 @@ components. It’s important to check regularly for new updates to the software
 and documentation.
 
 ## Migration to EigenDA Blazar (V2)
-EigenDA Blazar (V2) is a new version of the EigenDA protocol that is currently in development. <ins>It is not yet available on mainnet.</ins>
+EigenDA Blazar (V2) is the latest version of the EigenDA protocol.
 
 Current testnet operators running v1 must follow the [Blazar migration guide](./blazar-migration.md) to update their nodes to v2.
 


### PR DESCRIPTION
Bundled two small changes together for this PR

- proxy releases are now just linked to, instead of being in an outdated table
- I removed the statement that v2 isn't on mainnet yet